### PR TITLE
remove empty platform definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
   "peerDependencies": {},
   "bundledDependencies": [],
   "optionalDependencies": {},
-  "engines": {},
-  "os": [],
-  "cpu": [],
   "preferGlobal": false,
   "private": false,
   "publishConfig": {}


### PR DESCRIPTION
According to [the spec](https://docs.npmjs.com/files/package.json#engines), empty array means there that this package compatible with nothing.
In other words, there is no compatible platform at all.

Npm successfully installs this package, but some others, like [yarn](https://github.com/yarnpkg/yarn), more strictly follow this option and refuse to install incompatible packages.

--
*By the way, thank you for the awesome module, I am using this in every my project and it saves me a lot of typing for new components!*