### PR TITLE
remove empty os/cpu properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
   "bundledDependencies": [],
   "optionalDependencies": {},
   "engines": {},
-  "os": [],
-  "cpu": [],
   "preferGlobal": false,
   "private": false,
   "publishConfig": {}


### PR DESCRIPTION
This configuration basically says that this package is incompatible with every os and cpu architecture. npm ignores this, but the new [yarn](https://github.com/yarnpkg/yarn) package manager has an issue with this.

Should probably just remove all empty config options as well.